### PR TITLE
Add green earthy theme palette with large type and clear code blocks

### DIFF
--- a/assets/css/colors/earthy.css
+++ b/assets/css/colors/earthy.css
@@ -1,0 +1,42 @@
+/*
+ * "earthy" — a green, earthy colour palette for the typo theme.
+ *
+ * Colour-theory notes
+ * -------------------
+ * The palette is built around a single dominant hue family — forest / moss /
+ * olive greens (roughly hue 90-130) — and paired with *analogous* warm
+ * neutrals (parchment, sand, clay; hue 45-60) for the page and code surfaces.
+ * Greens sit opposite warm earth tones on the warm/cool axis, so the cream
+ * backgrounds read as a gentle near-complement to the green ink: enough
+ * contrast to be comfortable, never vibrant. Every hue is kept at low
+ * saturation so the whole thing feels natural and grounded rather than digital.
+ *
+ * Text/background pairings are tuned to clear WCAG AA contrast in both modes.
+ */
+
+:root {
+    /* Light: deep pine ink on warm parchment */
+    --content-primary: rgb(47, 58, 44);     /* #2f3a2c forest charcoal-green  */
+    --content-secondary: rgb(95, 107, 78);  /* #5f6b4e muted moss / olive      */
+    --background: rgb(243, 239, 227);        /* #f3efe3 warm parchment / sand   */
+    --code-background: rgb(233, 229, 212);   /* #e9e5d4 soft sage-cream         */
+    --code-border: rgb(200, 194, 166);       /* #c8c2a6 muted olive-tan         */
+
+    /* Legacy aliases used by reset.css */
+    --primary: var(--content-primary);
+    --secondary: var(--content-secondary);
+    --theme: var(--background);
+}
+
+.dark {
+    /* Dark: warm parchment ink on deep forest */
+    --content-primary: rgb(231, 226, 207);   /* #e7e2cf warm parchment / sand  */
+    --content-secondary: rgb(154, 166, 127);  /* #9aa67f sage                   */
+    --background: rgb(27, 32, 26);             /* #1b201a deep forest-black      */
+    --code-background: rgb(35, 42, 32);        /* #232a20 lifted forest          */
+    --code-border: rgb(60, 70, 52);            /* #3c4634 moss                   */
+
+    --primary: var(--content-primary);
+    --secondary: var(--content-secondary);
+    --theme: var(--background);
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,107 @@
+/* ------------------------------------------------------------------ *
+ * Project overrides for the typo theme.
+ * Loaded after main.css, so :root variable overrides here win.
+ * Two concerns:
+ *   1. Larger, more legible typography.
+ *   2. Earthy (gruvbox-derived) syntax highlighting that works in
+ *      both light and dark mode.
+ * ------------------------------------------------------------------ */
+
+/* 1. Typography -------------------------------------------------------- */
+
+:root {
+    /* A touch wider for a comfortable ~70-character measure */
+    --main-width: 820px;
+
+    /* Bigger body copy and roomier line spacing for legibility */
+    --p-font-size: 1.06em;
+    --p-line-height: 1.78em;
+
+    /* Stronger heading hierarchy */
+    --h1-font-size: 2.4em;
+    --h2-font-size: 1.9em;
+    --hx-font-size: 1.4em;
+}
+
+body {
+    /* Base bumped from the theme's 18px for larger, easier reading */
+    font-size: 20px;
+    line-height: 1.78;
+}
+
+@media screen and (max-width: 640px) {
+    body {
+        font-size: 18px;
+    }
+}
+
+/* Slightly larger, airier code for clarity */
+pre code {
+    font-size: 0.95em;
+    line-height: 1.6;
+}
+
+/* 2. Earthy syntax highlighting (class-based / noClasses = false) ------ *
+ *
+ * Colours are drawn from the gruvbox palette — the canonical earthy
+ * scheme — mapped onto an earthy-green spread: olive/forest greens for
+ * strings, amber/yellow for types and classes, clay-orange for keywords,
+ * teal for functions, plum for numbers, warm grey for comments.
+ *
+ * The code surface itself is left to the theme's --code-background, so
+ * highlighting stays cohesive with the earthy palette in both modes.
+ */
+
+.chroma {
+    background: transparent;
+}
+
+/* ---- Light mode (gruvbox light) ---- */
+.chroma .c, .chroma .ch, .chroma .cm, .chroma .c1,
+.chroma .cs, .chroma .cp, .chroma .cpf { color: #7c6f64; font-style: italic; } /* comments  */
+.chroma .k, .chroma .kc, .chroma .kd, .chroma .kn,
+.chroma .kp, .chroma .kr                  { color: #af3a03; }                  /* keywords  */
+.chroma .kt                               { color: #b57614; }                  /* k. types  */
+.chroma .o, .chroma .ow                   { color: #af3a03; }                  /* operators */
+.chroma .nb, .chroma .bp                  { color: #427b58; }                  /* builtins  */
+.chroma .nf, .chroma .fm                  { color: #427b58; }                  /* functions */
+.chroma .nc, .chroma .nn, .chroma .ne     { color: #b57614; }                  /* classes   */
+.chroma .no, .chroma .na, .chroma .nd,
+.chroma .nl, .chroma .py                  { color: #076678; }                  /* names     */
+.chroma .nt                               { color: #af3a03; }                  /* tags      */
+.chroma .s, .chroma .sa, .chroma .sb, .chroma .sc,
+.chroma .dl, .chroma .sd, .chroma .s2, .chroma .se,
+.chroma .sh, .chroma .si, .chroma .sx, .chroma .sr,
+.chroma .s1, .chroma .ss                  { color: #79740e; }                  /* strings   */
+.chroma .m, .chroma .mb, .chroma .mf, .chroma .mh,
+.chroma .mi, .chroma .il, .chroma .mo     { color: #8f3f71; }                  /* numbers   */
+.chroma .ge { font-style: italic; }
+.chroma .gs { font-weight: bold; }
+.chroma .gh, .chroma .gu { color: #79740e; font-weight: bold; }
+.chroma .gd { color: #9d0006; }
+.chroma .gi { color: #79740e; }
+.chroma .err { color: #9d0006; }
+
+/* ---- Dark mode (gruvbox dark) ---- */
+.dark .chroma .c, .dark .chroma .ch, .dark .chroma .cm, .dark .chroma .c1,
+.dark .chroma .cs, .dark .chroma .cp, .dark .chroma .cpf { color: #928374; font-style: italic; }
+.dark .chroma .k, .dark .chroma .kc, .dark .chroma .kd, .dark .chroma .kn,
+.dark .chroma .kp, .dark .chroma .kr                  { color: #fe8019; }
+.dark .chroma .kt                                     { color: #fabd2f; }
+.dark .chroma .o, .dark .chroma .ow                   { color: #fe8019; }
+.dark .chroma .nb, .dark .chroma .bp                  { color: #8ec07c; }
+.dark .chroma .nf, .dark .chroma .fm                  { color: #8ec07c; }
+.dark .chroma .nc, .dark .chroma .nn, .dark .chroma .ne { color: #fabd2f; }
+.dark .chroma .no, .dark .chroma .na, .dark .chroma .nd,
+.dark .chroma .nl, .dark .chroma .py                  { color: #83a598; }
+.dark .chroma .nt                                     { color: #fe8019; }
+.dark .chroma .s, .dark .chroma .sa, .dark .chroma .sb, .dark .chroma .sc,
+.dark .chroma .dl, .dark .chroma .sd, .dark .chroma .s2, .dark .chroma .se,
+.dark .chroma .sh, .dark .chroma .si, .dark .chroma .sx, .dark .chroma .sr,
+.dark .chroma .s1, .dark .chroma .ss                  { color: #b8bb26; }
+.dark .chroma .m, .dark .chroma .mb, .dark .chroma .mf, .dark .chroma .mh,
+.dark .chroma .mi, .dark .chroma .il, .dark .chroma .mo { color: #d3869b; }
+.dark .chroma .gh, .dark .chroma .gu { color: #b8bb26; }
+.dark .chroma .gd { color: #fb4934; }
+.dark .chroma .gi { color: #b8bb26; }
+.dark .chroma .err { color: #fb4934; }

--- a/hugo.toml
+++ b/hugo.toml
@@ -14,7 +14,7 @@ tag = 'tags'
 description = "Blog blog"
 paginationSize = 25
 theme = 'auto'
-colorPalette = 'catpuccin'
+colorPalette = 'earthy'
 hideHeader = 'true'
 # The path to your favicon
 favicon = "images/favicon.png"
@@ -38,10 +38,15 @@ url = "/posts"
 name = "trivial pursuits"
 url = "/trivial-pursuits"
 
-# Syntax highlight on code blocks
+# Syntax highlight on code blocks.
+# noClasses = false makes Chroma emit CSS classes (.chroma .k, ...) instead of
+# inline colours, so the earthy light/dark highlighting in custom.css applies.
 [markup]
 [markup.highlight]
-style = 'algol'
+noClasses = false
+guessSyntax = true
+lineNos = false
+tabWidth = 4
 
 
 [[params.social]]


### PR DESCRIPTION
- Add project-level 'earthy' colour palette (forest/moss greens with warm
  parchment and sand neutrals) for the typo theme, tuned for AA contrast in
  both light and dark mode.
- Enlarge body typography and headings for legibility via custom.css.
- Switch code highlighting to class-based Chroma with a gruvbox-derived
  earthy scheme that adapts to light/dark, leaving the code surface to the
  palette so it stays cohesive.

https://claude.ai/code/session_01Q2MzaZitPx6JHPjCShC3PH