### PR TITLE
Restyle nav links and post dates to match earthy serif theme

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -41,6 +41,72 @@ pre code {
     line-height: 1.6;
 }
 
+/* Header nav links: serif, not monospace, to match the wider theme.
+ * Small uppercase, letter-spaced, in muted moss-green; the active page
+ * stands out in the primary ink. Underline appears only on hover. */
+.header-menu p {
+    font-family: var(--font-body);
+    font-size: 0.78em;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-right: 1.25rem;
+}
+
+.header-menu a {
+    color: var(--content-secondary);
+    text-decoration: none;
+}
+
+.header-menu a:hover {
+    color: var(--content-primary);
+    text-decoration: underline;
+    text-underline-offset: 0.25em;
+}
+
+.header-menu p.bold a {
+    color: var(--content-primary);
+}
+
+/* Breadcrumbs are the same nav on inner pages (header is hidden there),
+ * and the back-to-top link is the same chrome — keep them serif too so
+ * nothing reverts to the code monospace. */
+.breadcrumbs,
+.back-to-top {
+    font-family: var(--font-body);
+    font-size: 0.78em;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--content-secondary);
+}
+
+.breadcrumbs a,
+.back-to-top a {
+    color: var(--content-secondary);
+}
+
+.breadcrumbs a:hover,
+.back-to-top a:hover {
+    color: var(--content-primary);
+}
+
+.breadcrumbs-separator {
+    color: var(--content-secondary);
+    opacity: 0.6;
+}
+
+/* Post-list dates: serif with tabular, lining figures so the left-hand
+ * date column still aligns despite the proportional serif face. */
+.line-date {
+    font-family: var(--font-body);
+    font-variant-numeric: tabular-nums lining-nums;
+    font-feature-settings: "tnum" 1, "lnum" 1;
+    font-size: 0.82em;
+    letter-spacing: 0.02em;
+    color: var(--content-secondary);
+    min-width: 130px;
+    max-width: 130px;
+}
+
 /* 2. Earthy syntax highlighting (class-based / noClasses = false) ------ *
  *
  * Colours are drawn from the gruvbox palette — the canonical earthy

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,32 @@
+{{/* Header (project override of typo theme) */}}
+{{/* Nav names render without the leading slash so they sit cleanly as     */}}
+{{/* uppercase, letter-spaced serif links — see .header-menu in custom.css. */}}
+
+<div class="header">
+
+    {{ if or (not (.Param "hideHeader")) .IsHome }}
+
+    <h1 class="header-title">
+        <a href="{{ site.BaseURL }}">{{ site.Title }}</a>
+    </h1>
+
+    <div class="header-menu">
+        {{ $currentPage := . }}
+
+        {{ with site.Params.menu }}
+        {{ range . }}
+
+        <p
+            class="small {{ if eq .name (lower $currentPage.Name) }} bold {{end}}">
+            <a href="{{ .url }}" {{ if and (isset . "newTab") .newTab
+                }}target="_blank" rel="noopener noreferrer" {{ end }}>
+                {{ .name }}
+            </a>
+        </p>
+        {{ end }}
+        {{ end }}
+    </div>
+
+    {{ end }}
+
+</div>


### PR DESCRIPTION
The header menu, post-list dates, breadcrumbs and back-to-top link were rendered in the Monaspace monospace used for code, which clashed with the Literata serif of the rest of the earthy theme. This moves all of that chrome into the serif family for a cohesive, editorial look.

## Changes
- **Nav links** (`HOME` · `POSTS` · `TRIVIAL PURSUITS`): small uppercase, letter-spaced serif in muted moss-green; the active page shows in the primary ink. The terminal-style leading `/` is dropped via a small project-level override of the theme's `header.html` partial.
- **Post-list dates**: serif with tabular lining figures (`font-variant-numeric: tabular-nums lining-nums`) so the left-hand date column still aligns despite the proportional serif face.
- **Breadcrumbs + back-to-top**: same serif treatment, since on inner pages the header menu is hidden (`hideHeader = true`) and the breadcrumb is the de-facto navigation there.

All changes live in project-level files (`assets/css/custom.css`, `layouts/partials/header.html`); the `typo` theme submodule is untouched.

## Verification
Built with Hugo (clean, no errors) and rendered the home and posts pages in both light and dark mode to confirm the nav, dates, and breadcrumbs all render in the serif and the date column stays aligned.

https://claude.ai/code/session_01Q2MzaZitPx6JHPjCShC3PH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2MzaZitPx6JHPjCShC3PH)_