### PR TITLE
Improve SEO: descriptions, robots.txt, social cards, structured data

### DIFF
--- a/content/posts/2010-05-13-python-aes.md
+++ b/content/posts/2010-05-13-python-aes.md
@@ -2,6 +2,7 @@
 date: 2010-05-13 18:59:00+00:00
 slug: python-aes
 title: Python AES
+description: "A short example of doing AES encryption in Python with the PyCrypto toolkit."
 wordpress_id: 24
 categories:
 - aes

--- a/content/posts/2024-08-01-ham.md
+++ b/content/posts/2024-08-01-ham.md
@@ -4,6 +4,7 @@ date: 2024-08-01 16:00:00+01:00
 
 slug: 2024-08-01-ham
 title: Ham or spam?
+description: "Switching the blog's deploy to GitHub Actions, plus beginner notes on amateur radio experiments with a Baofeng UV-5RH and a pair of kids' walkie-talkies."
 categories:
     - ham
 

--- a/content/posts/2024-08-13-pan-shan.md
+++ b/content/posts/2024-08-13-pan-shan.md
@@ -4,6 +4,7 @@ date: 2024-08-13 07:00:00+01:00
 
 slug: 2024-08-13-pan
 title: Don't use PAN numbers as passwords!
+description: "Why Indian financial firms using your PAN as the password to protect account statements is a terrible idea — and how few characters you'd actually need to brute-force one."
 categories:
     - security
     - passwords

--- a/content/posts/2025-01-31-deepseek-mania.md
+++ b/content/posts/2025-01-31-deepseek-mania.md
@@ -4,6 +4,7 @@ date: 2025-01-31 05:30:00+00:00
 
 slug: 2024-01-31-flappy-tburd
 title: Checking out Deepseek R1
+description: "Vibe-coding a Flappy Bird clone in Rust and Bevy using DeepSeek R1 — what the model got right, where it broke on outdated crate APIs, and my take on its chain-of-thought reasoning."
 categories:
     - software
     - games

--- a/content/posts/2025-03-18-wireguard-notes.md
+++ b/content/posts/2025-03-18-wireguard-notes.md
@@ -2,6 +2,7 @@
 date: 2025-03-18 21:06:24+0000
 slug: 2025-03-18-wg-notes
 title: WireGuard notes
+description: "Practical notes on WireGuard, the modern VPN: how its architecture keeps the attack surface small, why it ships by default on Linux, and tips from setting it up."
 categories:
     - software
     - networks

--- a/hugo.toml
+++ b/hugo.toml
@@ -5,13 +5,24 @@ theme = "typo"
 title='Ritesh is Rambling'
 copyright = "Ritesh Sinha"
 
+# Generate robots.txt (uses layouts/robots.txt) so crawlers find the sitemap.
+enableRobotsTXT = true
 
 [taxonomies]
 tag = 'tags'
 
+# Sitemap defaults for the auto-generated sitemap.xml.
+[sitemap]
+  changefreq = "weekly"
+  priority = 0.5
+  filename = "sitemap.xml"
+
 [params]
-  # The description of your website
-description = "Blog blog"
+  # Author, used for SEO metadata and structured data.
+author = "Ritesh Sinha"
+  # The description of your website, used for the homepage meta description,
+  # Open Graph tags, and as a fallback for pages without their own description.
+description = "Ritesh Sinha's blog on software security, programming, Linux, and assorted tinkering — a mix of technical notes and personal posts."
 paginationSize = 25
 theme = 'auto'
 colorPalette = 'earthy'
@@ -55,4 +66,4 @@ url = "https://github.com/ritesh"
 
 [[params.social]]
 name = "linkedin"
-url = "mailto:r@example.org"
+url = "https://uk.linkedin.com/in/riteshks"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,61 @@
+{{/* Project override of the typo theme's head partial.                     */}}
+{{/* Kept in sync with the upstream theme, with one change: the meta         */}}
+{{/* description now falls back to the page summary and then the site        */}}
+{{/* description, instead of rendering an empty tag on posts that lack a     */}}
+{{/* `description` in their front matter (which is all of them).             */}}
+
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+
+{{/* Head start hook */}}
+{{ partial "functions/get_hook.html" (dict "hook" "head_start" "context" .) }}
+
+{{ $faviconPath := (.Site.Params.faviconPath | default "" | absURL) }}
+
+<link rel="icon" type="image/ico" href="{{ urls.JoinPath $faviconPath "favicon.ico" }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ urls.JoinPath $faviconPath "favicon-16x16.png" }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ urls.JoinPath $faviconPath "favicon-32x32.png" }}">
+<link rel="icon" type="image/png" sizes="192x192" href="{{ urls.JoinPath $faviconPath "android-chrome-192x192.png" }}">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ urls.JoinPath $faviconPath "apple-touch-icon.png" }}">
+
+{{ with .OutputFormats.Get "rss" -}}
+{{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+{{ end }}
+
+{{- $description := "" -}}
+{{- if .IsHome -}}
+    {{- $description = site.Params.Description -}}
+{{- else -}}
+    {{- $description = or .Params.Description .Description .Summary site.Params.Description -}}
+{{- end -}}
+<meta name="description" content="{{ $description | plainify | htmlUnescape | chomp }}"/>
+
+{{ if .Param "fediverse" }}
+<meta name="fediverse:creator" content="{{ .Params.Fediverse }}">
+{{ end }}
+
+<title>
+    {{ if .IsHome }}
+    {{ site.Title }}
+    {{ else }}
+    {{ printf "%s | %s" .Title site.Title }}
+    {{ end }}
+</title>
+
+<link rel="canonical" href="{{ .Permalink }}"/>
+
+{{ template "partials/opengraph.html" . }}
+
+{{ partialCached "head/css.html" . }}
+{{ partialCached "head/js.html" . }}
+
+{{ if hugo.IsProduction }}
+{{ template "_internal/google_analytics.html" . }}
+
+{{ if .Site.Params.umami.enable }}
+{{ partial "umami.html" . }}
+{{ end }}
+{{ end }}
+
+{{/* Head end hook */}}
+{{ partial "functions/get_hook.html" (dict "hook" "head_end" "context" .) }}

--- a/layouts/partials/hooks/head_end.html
+++ b/layouts/partials/hooks/head_end.html
@@ -1,0 +1,52 @@
+{{/* Project SEO additions injected into <head> via the typo theme's        */}}
+{{/* head_end hook (see partials/functions/get_hook.html).                   */}}
+
+{{/* Resolve a description using the same fallback chain as head.html. */}}
+{{- $description := "" -}}
+{{- if .IsHome -}}
+    {{- $description = site.Params.Description -}}
+{{- else -}}
+    {{- $description = or .Params.Description .Description .Summary site.Params.Description -}}
+{{- end -}}
+{{- $description = $description | plainify | htmlUnescape | chomp -}}
+
+{{- $title := cond .IsHome site.Title (printf "%s | %s" .Title site.Title) -}}
+
+{{/* Twitter / X card. twitter:image is omitted on purpose — X falls back to
+     the og:image emitted by opengraph.html. */}}
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $title }}">
+{{- with $description }}
+<meta name="twitter:description" content="{{ . }}">
+{{- end }}
+
+{{/* JSON-LD structured data for richer search results. */}}
+{{- $author := or site.Params.author site.Title -}}
+{{- if .IsPage -}}
+  {{- $schema := dict
+      "@context" "https://schema.org"
+      "@type" "BlogPosting"
+      "headline" .Title
+      "url" .Permalink
+      "mainEntityOfPage" .Permalink
+      "datePublished" (.PublishDate.Format "2006-01-02T15:04:05Z07:00")
+      "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+      "author" (dict "@type" "Person" "name" $author)
+      "publisher" (dict "@type" "Person" "name" $author)
+  -}}
+  {{- with $description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
+  {{- $tags := slice -}}
+  {{- range .GetTerms "tags" }}{{ $tags = $tags | append .Page.Title }}{{ end -}}
+  {{- with $tags }}{{ $schema = merge $schema (dict "keywords" (delimit . ", ")) }}{{ end -}}
+  <script type="application/ld+json">{{ $schema | jsonify (dict "indent" "  ") | safeJS }}</script>
+{{- else -}}
+  {{- $schema := dict
+      "@context" "https://schema.org"
+      "@type" "WebSite"
+      "name" site.Title
+      "url" site.BaseURL
+      "author" (dict "@type" "Person" "name" $author)
+  -}}
+  {{- with $description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
+  <script type="application/ld+json">{{ $schema | jsonify (dict "indent" "  ") | safeJS }}</script>
+{{- end -}}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
The typo theme rendered an empty <meta name="description"> on every post
because no post had a `description` in its front matter, and the site
description was the placeholder "Blog blog". This adds the missing SEO
plumbing:

- hugo.toml: real site description, enableRobotsTXT, sitemap config,
  author param, and fix the placeholder LinkedIn social URL.
- layouts/partials/head.html: project override of the theme partial so the
  meta description falls back to the page summary, then the site
  description, instead of being empty on posts.
- layouts/partials/hooks/head_end.html: Twitter/X card tags and JSON-LD
  structured data (BlogPosting for posts, WebSite for the home page),
  injected via the theme's head_end hook.
- layouts/robots.txt: allow crawling and advertise the sitemap.
- Add explicit descriptions to several flagship posts for better search
  snippets.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T3h7nJ66ohx1phAvcN1B1g